### PR TITLE
Add filter command for task and people

### DIFF
--- a/src/main/java/seedu/address/logic/commands/contact/FilterContactCommand.java
+++ b/src/main/java/seedu/address/logic/commands/contact/FilterContactCommand.java
@@ -9,21 +9,21 @@ import seedu.address.model.Model;
 import seedu.address.model.person.PersonContainsKeywordsPredicate;
 
 /**
- * Finds and lists all persons in address book whose fields contain any of the argument keywords.
+ * Finds and lists all persons whose tags contain any of the argument keywords.
  * Keyword matching is case-insensitive.
  */
-public class FindContactCommand extends Command {
+public class FilterContactCommand extends Command {
 
-    public static final String COMMAND_WORD = "findC";
+    public static final String COMMAND_WORD = "filterC";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all persons whose names contain any of "
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all persons whose tag(s) contain any of "
             + "the specified keywords (case-insensitive) and displays them as a list with index numbers.\n"
             + "Parameters: KEYWORD [MORE_KEYWORDS]...\n"
-            + "Example: " + COMMAND_WORD + " alice bob charlie";
+            + "Example: " + COMMAND_WORD + " grocery shopping friends";
 
     private final PersonContainsKeywordsPredicate predicate;
 
-    public FindContactCommand(PersonContainsKeywordsPredicate predicate) {
+    public FilterContactCommand(PersonContainsKeywordsPredicate predicate) {
         this.predicate = predicate;
     }
 
@@ -38,7 +38,7 @@ public class FindContactCommand extends Command {
     @Override
     public boolean equals(Object other) {
         return other == this // short circuit if same object
-                || (other instanceof FindContactCommand // instanceof handles nulls
-                && predicate.equals(((FindContactCommand) other).predicate)); // state check
+                || (other instanceof FilterContactCommand // instanceof handles nulls
+                && predicate.equals(((FilterContactCommand) other).predicate)); // state check
     }
 }

--- a/src/main/java/seedu/address/logic/commands/task/FilterTaskCommand.java
+++ b/src/main/java/seedu/address/logic/commands/task/FilterTaskCommand.java
@@ -1,0 +1,46 @@
+package seedu.address.logic.commands.task;
+
+import static java.util.Objects.requireNonNull;
+
+import seedu.address.commons.core.Messages;
+import seedu.address.logic.commands.Command;
+import seedu.address.logic.commands.CommandResult;
+import seedu.address.model.Model;
+import seedu.address.model.task.TaskContainsKeywordsPredicate;
+
+/**
+ * Finds and lists all tasks whose tags contain any of the argument keywords.
+ * Keyword matching is case-insensitive.
+ */
+public class FilterTaskCommand extends Command {
+
+    public static final String COMMAND_WORD = "filterT";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Finds all tasks whose description/deadline contain any of "
+            + "the specified keywords (case-insensitive) and displays them as a list with index numbers.\n"
+            + "Parameters: KEYWORD [MORE_KEYWORDS]...\n"
+            + "Example: " + COMMAND_WORD + " grocery shopping friends";
+
+    private final TaskContainsKeywordsPredicate predicate;
+
+    public FilterTaskCommand(TaskContainsKeywordsPredicate predicate) {
+        this.predicate = predicate;
+    }
+
+    @Override
+    public CommandResult execute(Model model) {
+        requireNonNull(model);
+        model.updateFilteredTaskList(predicate);
+        return new CommandResult(
+                String.format(Messages.MESSAGE_TASKS_LISTED_OVERVIEW,
+                        model.getFilteredTaskList().size()));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof FilterTaskCommand // instanceof handles nulls
+                && predicate.equals(((FilterTaskCommand) other).predicate)); // state check
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -13,12 +13,14 @@ import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.contact.AddContactCommand;
 import seedu.address.logic.commands.contact.DeleteContactCommand;
 import seedu.address.logic.commands.contact.EditContactCommand;
+import seedu.address.logic.commands.contact.FilterContactCommand;
 import seedu.address.logic.commands.contact.FindContactCommand;
 import seedu.address.logic.commands.contact.ListContactCommand;
 import seedu.address.logic.commands.tag.AddTagCommand;
 import seedu.address.logic.commands.tag.DeleteTagCommand;
 import seedu.address.logic.commands.task.AddTaskCommand;
 import seedu.address.logic.commands.task.EditTaskCommand;
+import seedu.address.logic.commands.task.FilterTaskCommand;
 import seedu.address.logic.commands.task.FindTaskCommand;
 import seedu.address.logic.commands.task.ListTaskCommand;
 import seedu.address.logic.commands.task.MarkTaskCommand;
@@ -26,12 +28,14 @@ import seedu.address.logic.commands.task.UnmarkTaskCommand;
 import seedu.address.logic.parser.contact.AddContactCommandParser;
 import seedu.address.logic.parser.contact.DeleteContactCommandParser;
 import seedu.address.logic.parser.contact.EditContactCommandParser;
+import seedu.address.logic.parser.contact.FilterContactCommandParser;
 import seedu.address.logic.parser.contact.FindContactCommandParser;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.logic.parser.tag.AddTagCommandParser;
 import seedu.address.logic.parser.tag.DeleteTagCommandParser;
 import seedu.address.logic.parser.task.AddTaskCommandParser;
 import seedu.address.logic.parser.task.EditTaskCommandParser;
+import seedu.address.logic.parser.task.FilterTaskCommandParser;
 import seedu.address.logic.parser.task.FindTaskCommandParser;
 import seedu.address.logic.parser.task.MarkTaskCommandParser;
 import seedu.address.logic.parser.task.UnmarkTaskCommandParser;
@@ -78,6 +82,9 @@ public class AddressBookParser {
         case FindContactCommand.COMMAND_WORD:
             return new FindContactCommandParser().parse(arguments);
 
+        case FilterContactCommand.COMMAND_WORD:
+            return new FilterContactCommandParser().parse(arguments);
+
         case ListContactCommand.COMMAND_WORD:
             return new ListContactCommand();
 
@@ -101,6 +108,9 @@ public class AddressBookParser {
 
         case FindTaskCommand.COMMAND_WORD:
             return new FindTaskCommandParser().parse(arguments);
+
+        case FilterTaskCommand.COMMAND_WORD:
+            return new FilterTaskCommandParser().parse(arguments);
 
         case MarkTaskCommand.COMMAND_WORD:
             return new MarkTaskCommandParser().parse(arguments);

--- a/src/main/java/seedu/address/logic/parser/contact/FilterContactCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/contact/FilterContactCommandParser.java
@@ -1,0 +1,37 @@
+package seedu.address.logic.parser.contact;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import java.util.List;
+
+import seedu.address.logic.commands.contact.FilterContactCommand;
+import seedu.address.logic.parser.Parser;
+import seedu.address.logic.parser.ParserUtil;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.person.PersonContainsKeywordsPredicate;
+
+/**
+ * Parses input arguments and creates a new FilterContactCommandParser object
+ */
+public class FilterContactCommandParser implements Parser<FilterContactCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the FilterContactCommand
+     * and returns a FilterContactCommand object for execution.
+     *
+     * @param args Raw arguments from user.
+     * @return FilterContactCommand object.
+     * @throws ParseException If the user input does not conform the expected format
+     */
+    public FilterContactCommand parse(String args) throws ParseException {
+        String trimmedArgs = args.trim();
+        List<String> tags = List.of(trimmedArgs.split(" "));
+
+        if (tags.isEmpty()) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, FilterContactCommand.MESSAGE_USAGE));
+        }
+
+        return new FilterContactCommand(new PersonContainsKeywordsPredicate(ParserUtil.parseTags(tags)));
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/contact/FindContactCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/contact/FindContactCommandParser.java
@@ -31,7 +31,10 @@ public class FindContactCommandParser implements Parser<FindContactCommand> {
     /**
      * Parses the given {@code String} of arguments in the context of the FindContactCommand
      * and returns a FindContactCommand object for execution.
-     * @throws ParseException if the user input does not conform the expected format
+     *
+     * @param args Raw arguments from user.
+     * @return FindContactCommand object.
+     * @throws ParseException If the user input does not conform the expected format
      */
     public FindContactCommand parse(String args) throws ParseException {
         ArgumentMultimap argMultimap =
@@ -42,8 +45,7 @@ public class FindContactCommandParser implements Parser<FindContactCommand> {
                 PREFIX_PHONE, PREFIX_EMAIL)
                 || !argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(
-                    String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                            FindContactCommand.MESSAGE_USAGE));
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindContactCommand.MESSAGE_USAGE));
         }
 
         List<Name> names = getNames(argMultimap);

--- a/src/main/java/seedu/address/logic/parser/task/FilterTaskCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/task/FilterTaskCommandParser.java
@@ -1,0 +1,37 @@
+package seedu.address.logic.parser.task;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import java.util.List;
+
+import seedu.address.logic.commands.task.FilterTaskCommand;
+import seedu.address.logic.parser.Parser;
+import seedu.address.logic.parser.ParserUtil;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.task.TaskContainsKeywordsPredicate;
+
+/**
+ * Parses input arguments and creates a new FilterTaskCommandParser object
+ */
+public class FilterTaskCommandParser implements Parser<FilterTaskCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the FilterTaskCommand
+     * and returns a FilterTaskCommand object for execution.
+     *
+     * @param args Raw arguments from user.
+     * @return FilterTaskCommand object.
+     * @throws ParseException If the user input does not conform the expected format
+     */
+    public FilterTaskCommand parse(String args) throws ParseException {
+        String trimmedArgs = args.trim();
+        List<String> tags = List.of(trimmedArgs.split(" "));
+
+        if (tags.isEmpty()) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, FilterTaskCommand.MESSAGE_USAGE));
+        }
+
+        return new FilterTaskCommand(new TaskContainsKeywordsPredicate(ParserUtil.parseTags(tags)));
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/task/FindTaskCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/task/FindTaskCommandParser.java
@@ -27,7 +27,10 @@ public class FindTaskCommandParser implements Parser<FindTaskCommand> {
     /**
      * Parses the given {@code String} of arguments in the context of the FindTaskCommandParser
      * and returns a FindTaskCommand object for execution.
-     * @throws ParseException if the user input does not conform the expected format
+     *
+     * @param args Raw arguments from user input.
+     * @return FindTaskCommand object.
+     * @throws ParseException If the user input does not conform the expected format
      */
     public FindTaskCommand parse(String args) throws ParseException {
         ArgumentMultimap argMultimap =

--- a/src/main/java/seedu/address/model/person/PersonContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/PersonContainsKeywordsPredicate.java
@@ -1,9 +1,14 @@
 package seedu.address.model.person;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.function.Predicate;
 
 import seedu.address.commons.util.StringUtil;
+import seedu.address.model.tag.Tag;
 
 /**
  * Tests that a {@code Person}'s {@code Name} and/or {@code Phone} and/or {@code Email} and/or {@code Address}
@@ -14,6 +19,7 @@ public class PersonContainsKeywordsPredicate implements Predicate<Person> {
     private final List<Phone> phoneKeywords;
     private final List<Email> emailKeywords;
     private final List<Address> addressKeywords;
+    private final Set<Tag> tags;
 
     /**
      * Constructs an {@code PersonContainsKeywordsPredicate}.
@@ -29,8 +35,24 @@ public class PersonContainsKeywordsPredicate implements Predicate<Person> {
         this.phoneKeywords = phoneKeywords;
         this.emailKeywords = emailKeywords;
         this.addressKeywords = addressKeywords;
+        this.tags = new HashSet<>();
+
     }
 
+    /**
+     * Constructs an {@code PersonContainsKeywordsPredicate}.
+     *
+     * @param tags A set containing search terms for {@code Tag}.
+     */
+    public PersonContainsKeywordsPredicate(Set<Tag> tags) {
+        this.nameKeywords = new ArrayList<>();
+        this.phoneKeywords = new ArrayList<>();
+        this.emailKeywords = new ArrayList<>();
+        this.addressKeywords = new ArrayList<>();
+        this.tags = tags;
+    }
+
+    // TODO: Implement for tags
     @Override
     public boolean test(Person person) {
         return (nameKeywords.isEmpty() || nameKeywords.stream().anyMatch(keyword ->
@@ -40,24 +62,17 @@ public class PersonContainsKeywordsPredicate implements Predicate<Person> {
                 && (emailKeywords.isEmpty() || emailKeywords.stream().anyMatch(keyword ->
                 StringUtil.containsWordIgnoreCase(person.getEmail().value, keyword.toString())))
                 && (addressKeywords.isEmpty() || addressKeywords.stream().anyMatch(keyword ->
-                StringUtil.containsWordIgnoreCase(person.getAddress().value, keyword.toString())));
+                StringUtil.containsWordIgnoreCase(person.getAddress().value, keyword.toString())))
+                && (tags.isEmpty() || !Collections.disjoint(tags, person.getTags()));
     }
 
     @Override
     public boolean equals(Object other) {
-        if (other == this) {
-            return true;
-        }
-
-        if (!(other instanceof PersonContainsKeywordsPredicate)) {
-            return false;
-        }
-
-        PersonContainsKeywordsPredicate castedOther = (PersonContainsKeywordsPredicate) other;
-
-        return nameKeywords.equals(castedOther.nameKeywords)
-                && phoneKeywords.equals(castedOther.phoneKeywords)
-                && emailKeywords.equals(castedOther.emailKeywords)
-                && addressKeywords.equals(castedOther.addressKeywords);
+        return other == this // short circuit if same object
+                || (other instanceof PersonContainsKeywordsPredicate // instanceof handles nulls
+                && nameKeywords.equals(((PersonContainsKeywordsPredicate) other).nameKeywords)) // state check
+                && emailKeywords.equals(((PersonContainsKeywordsPredicate) other).emailKeywords)
+                && addressKeywords.equals(((PersonContainsKeywordsPredicate) other).addressKeywords)
+                && tags.equals(((PersonContainsKeywordsPredicate) other).tags);
     }
 }

--- a/src/main/java/seedu/address/model/task/Task.java
+++ b/src/main/java/seedu/address/model/task/Task.java
@@ -92,12 +92,14 @@ public class Task {
      *
      * @param descriptionKeywords Possibly empty list containing keywords for {@code Description}.
      * @param deadlineKeywords Possibly empty list containing keywords for {@code Deadline}.
+     * @param tags Possibly empty set containing search terms for {@code Tag}.
      * @return boolean indicating if task contains supplied keywords.
      */
     public boolean containsKeywordsCaseInsensitive(List<Description> descriptionKeywords,
-                                                   List<Deadline> deadlineKeywords) {
+                                                   List<Deadline> deadlineKeywords, Set<Tag> tags) {
         return (descriptionKeywords.isEmpty() || descriptionKeywords.stream().anyMatch(description::equalsIgnoreCase))
-                && (deadlineKeywords.isEmpty() || deadlineKeywords.contains(deadline));
+                && (deadlineKeywords.isEmpty() || deadlineKeywords.contains(deadline))
+                && (tags.isEmpty() || !Collections.disjoint(tags, this.tags));
     }
 
     /**

--- a/src/main/java/seedu/address/model/task/TaskContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/task/TaskContainsKeywordsPredicate.java
@@ -1,7 +1,12 @@
 package seedu.address.model.task;
 
+import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.function.Predicate;
+
+import seedu.address.model.tag.Tag;
 
 /**
  * Tests that a {@code task}'s {@code Description} and/or {@code Deadline}
@@ -10,6 +15,7 @@ import java.util.function.Predicate;
 public class TaskContainsKeywordsPredicate implements Predicate<Task> {
     private final List<Description> descriptionKeywords;
     private final List<Deadline> deadlineKeywords;
+    private final Set<Tag> tags;
 
     /**
      * Constructs an {@code TaskContainsKeywordsPredicate}.
@@ -21,6 +27,18 @@ public class TaskContainsKeywordsPredicate implements Predicate<Task> {
                                          List<Deadline> deadlineKeywords) {
         this.descriptionKeywords = descriptionKeywords;
         this.deadlineKeywords = deadlineKeywords;
+        tags = new HashSet<>();
+    }
+
+    /**
+     * Constructs an {@code TaskContainsKeywordsPredicate}.
+     *
+     * @param tags A set containing search terms for {@code Tag}.
+     */
+    public TaskContainsKeywordsPredicate(Set<Tag> tags) {
+        this.descriptionKeywords = new ArrayList<>();
+        this.deadlineKeywords = new ArrayList<>();
+        this.tags = tags;
     }
 
     /**
@@ -30,9 +48,10 @@ public class TaskContainsKeywordsPredicate implements Predicate<Task> {
      * @param  task Task that will be checked for matching keywords.
      * @return boolean indicating if task contains supplied keywords.
      */
+    // TODO Implement for tags
     @Override
     public boolean test(Task task) {
-        return task.containsKeywordsCaseInsensitive(descriptionKeywords, deadlineKeywords);
+        return task.containsKeywordsCaseInsensitive(descriptionKeywords, deadlineKeywords, tags);
     }
 
     @Override
@@ -48,6 +67,7 @@ public class TaskContainsKeywordsPredicate implements Predicate<Task> {
         TaskContainsKeywordsPredicate castedOther = (TaskContainsKeywordsPredicate) other;
 
         return descriptionKeywords.equals(castedOther.descriptionKeywords)
-                && deadlineKeywords.equals(castedOther.deadlineKeywords);
+                && deadlineKeywords.equals(castedOther.deadlineKeywords)
+                && tags.equals(castedOther.tags);
     }
 }

--- a/src/test/java/seedu/address/logic/parser/FilterContactCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FilterContactCommandParserTest.java
@@ -1,0 +1,4 @@
+package seedu.address.logic.parser;
+
+public class FilterContactCommandParserTest {
+}

--- a/src/test/java/seedu/address/logic/parser/FilterTaskCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FilterTaskCommandParserTest.java
@@ -1,0 +1,4 @@
+package seedu.address.logic.parser;
+
+public class FilterTaskCommandParserTest {
+}

--- a/src/test/java/seedu/address/logic/parser/FindTaskCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindTaskCommandParserTest.java
@@ -1,0 +1,4 @@
+package seedu.address.logic.parser;
+
+public class FindTaskCommandParserTest {
+}


### PR DESCRIPTION
Users are unable to query based on tags.

Allowing quering using tags provides more flexibility in searching.

Let's,
* add filter command for contacts (filterC)
* add filter command for tasks (filterT)