### PR TITLE
Add copy email command

### DIFF
--- a/src/main/java/seedu/address/commons/core/Messages.java
+++ b/src/main/java/seedu/address/commons/core/Messages.java
@@ -9,7 +9,6 @@ public class Messages {
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
     public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX = "The person index provided is invalid";
     public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d persons listed!";
-    public static final String MESSAGE_COPIED_EMAILS = "Emails: %s";
     public static final String MESSAGE_INVALID_TASK_DISPLAYED_INDEX = "The task index provided is invalid";
     public static final String MESSAGE_TASKS_LISTED_OVERVIEW = "%1$d tasks listed!";
 }

--- a/src/main/java/seedu/address/commons/core/Messages.java
+++ b/src/main/java/seedu/address/commons/core/Messages.java
@@ -9,7 +9,7 @@ public class Messages {
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
     public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX = "The person index provided is invalid";
     public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d persons listed!";
+    public static final String MESSAGE_COPIED_EMAILS = "Emails: %s";
     public static final String MESSAGE_INVALID_TASK_DISPLAYED_INDEX = "The task index provided is invalid";
-
     public static final String MESSAGE_TASKS_LISTED_OVERVIEW = "%1$d tasks listed!";
 }

--- a/src/main/java/seedu/address/logic/commands/contact/CopyContactEmailCommand.java
+++ b/src/main/java/seedu/address/logic/commands/contact/CopyContactEmailCommand.java
@@ -4,7 +4,6 @@ import static java.util.Objects.requireNonNull;
 
 import java.util.List;
 
-import seedu.address.commons.core.Messages;
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.model.Model;
@@ -22,6 +21,7 @@ public class CopyContactEmailCommand extends Command {
             + "the specified tag (case-sensitive) for easy copy-pasting.\n"
             + "Parameters: TAG.\n"
             + "Example: " + COMMAND_WORD + " CS2103T";
+    public static final String MESSAGE_COPIED_EMAILS = "Emails: %s";
 
     private final PersonContainsKeywordsPredicate predicate;
 
@@ -41,7 +41,7 @@ public class CopyContactEmailCommand extends Command {
         }
 
         return new CommandResult(
-                String.format(Messages.MESSAGE_COPIED_EMAILS, builder.toString()));
+                String.format(MESSAGE_COPIED_EMAILS, builder.toString()));
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/contact/CopyContactEmailCommand.java
+++ b/src/main/java/seedu/address/logic/commands/contact/CopyContactEmailCommand.java
@@ -1,0 +1,53 @@
+package seedu.address.logic.commands.contact;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.List;
+
+import seedu.address.commons.core.Messages;
+import seedu.address.logic.commands.Command;
+import seedu.address.logic.commands.CommandResult;
+import seedu.address.model.Model;
+import seedu.address.model.person.Person;
+import seedu.address.model.person.PersonContainsKeywordsPredicate;
+
+/**
+ * Lists all emails of people whose tags contain the argument keyword.
+ * Keyword matching is case-sensitive.
+ */
+public class CopyContactEmailCommand extends Command {
+    public static final String COMMAND_WORD = "copyC";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Displays emails of all persons whose taglist contains "
+            + "the specified tag (case-sensitive) for easy copy-pasting.\n"
+            + "Parameters: TAG.\n"
+            + "Example: " + COMMAND_WORD + " CS2103T";
+
+    private final PersonContainsKeywordsPredicate predicate;
+
+    public CopyContactEmailCommand(PersonContainsKeywordsPredicate predicate) {
+        this.predicate = predicate;
+    }
+
+    @Override
+    public CommandResult execute(Model model) {
+        requireNonNull(model);
+        model.updateFilteredPersonList(predicate);
+
+        StringBuilder builder = new StringBuilder();
+        List<Person> people = model.getFilteredPersonList();
+        for (Person p : people) {
+            builder.append(p.getEmail().toString() + " ");
+        }
+
+        return new CommandResult(
+                String.format(Messages.MESSAGE_COPIED_EMAILS, builder.toString()));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof CopyContactEmailCommand // instanceof handles nulls
+                && predicate.equals(((CopyContactEmailCommand) other).predicate)); // state check
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/contact/FilterContactCommand.java
+++ b/src/main/java/seedu/address/logic/commands/contact/FilterContactCommand.java
@@ -10,14 +10,14 @@ import seedu.address.model.person.PersonContainsKeywordsPredicate;
 
 /**
  * Finds and lists all persons whose tags contain any of the argument keywords.
- * Keyword matching is case-insensitive.
+ * Keyword matching is case-sensitive.
  */
 public class FilterContactCommand extends Command {
 
     public static final String COMMAND_WORD = "filterC";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all persons whose tag(s) contain any of "
-            + "the specified keywords (case-insensitive) and displays them as a list with index numbers.\n"
+            + "the specified keywords (case-sensitive) and displays them as a list with index numbers.\n"
             + "Parameters: KEYWORD [MORE_KEYWORDS]...\n"
             + "Example: " + COMMAND_WORD + " grocery shopping friends";
 

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -13,6 +13,7 @@ import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.RedoCommand;
 import seedu.address.logic.commands.UndoCommand;
 import seedu.address.logic.commands.contact.AddContactCommand;
+import seedu.address.logic.commands.contact.CopyContactEmailCommand;
 import seedu.address.logic.commands.contact.DeleteContactCommand;
 import seedu.address.logic.commands.contact.EditContactCommand;
 import seedu.address.logic.commands.contact.FilterContactCommand;
@@ -32,6 +33,7 @@ import seedu.address.logic.commands.task.SortByDeadlineCommand;
 import seedu.address.logic.commands.task.SortByIdCommand;
 import seedu.address.logic.commands.task.UnmarkTaskCommand;
 import seedu.address.logic.parser.contact.AddContactCommandParser;
+import seedu.address.logic.parser.contact.CopyContactEmailCommandParser;
 import seedu.address.logic.parser.contact.DeleteContactCommandParser;
 import seedu.address.logic.parser.contact.EditContactCommandParser;
 import seedu.address.logic.parser.contact.FilterContactCommandParser;
@@ -84,9 +86,6 @@ public class AddressBookParser {
         case DeleteContactCommand.COMMAND_WORD:
             return new DeleteContactCommandParser().parse(arguments);
 
-        case ClearCommand.COMMAND_WORD:
-            return new ClearCommand();
-
         case FindContactCommand.COMMAND_WORD:
             return new FindContactCommandParser().parse(arguments);
 
@@ -95,6 +94,12 @@ public class AddressBookParser {
 
         case ListContactCommand.COMMAND_WORD:
             return new ListContactCommand();
+
+        case CopyContactEmailCommand.COMMAND_WORD:
+            return new CopyContactEmailCommandParser().parse(arguments);
+
+        case ClearCommand.COMMAND_WORD:
+            return new ClearCommand();
 
         case ExitCommand.COMMAND_WORD:
             return new ExitCommand();
@@ -175,6 +180,7 @@ public class AddressBookParser {
         case FindContactCommand.COMMAND_WORD:
         case FilterContactCommand.COMMAND_WORD:
         case ListContactCommand.COMMAND_WORD:
+        case CopyContactEmailCommand.COMMAND_WORD:
             return 0;
 
         case ExitCommand.COMMAND_WORD:

--- a/src/main/java/seedu/address/logic/parser/contact/CopyContactEmailCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/contact/CopyContactEmailCommandParser.java
@@ -1,0 +1,38 @@
+package seedu.address.logic.parser.contact;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import java.util.List;
+
+import seedu.address.logic.commands.contact.CopyContactEmailCommand;
+import seedu.address.logic.parser.Parser;
+import seedu.address.logic.parser.ParserUtil;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.person.PersonContainsKeywordsPredicate;
+
+/**
+ * Parses input arguments and creates a new CopyContactEmailCommandParser object.
+ */
+public class CopyContactEmailCommandParser implements Parser<CopyContactEmailCommand> {
+    /**
+     * Parses the given {@code String} of arguments in the context of the CopyContactEmailCommand
+     * and returns a CopyContactEmailCommand object for execution.
+     *
+     * @param arg input from user.
+     * @return CopyContactEmailCommand object.
+     * @throws ParseException If the user input does not conform the expected format
+     */
+    public CopyContactEmailCommand parse(String arg) throws ParseException {
+        requireNonNull(arg);
+        String trimmedArg = arg.trim();
+
+        if (trimmedArg.isEmpty()) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, CopyContactEmailCommand.MESSAGE_USAGE));
+        }
+
+        List<String> tags = List.of(trimmedArg);
+        return new CopyContactEmailCommand(new PersonContainsKeywordsPredicate(ParserUtil.parseTags(tags)));
+    }
+}


### PR DESCRIPTION
Users have to search for each team member and separately copy their emails from their contact details.

It will be more convenient for them to be able to copy a string of emails of all team members with a particular tag.

Let's add copy email command.